### PR TITLE
Add option to export a list of the expanded objects, interactions and datatypes in JSON format

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ The following configuration options are available to control the Java Bean expan
 - Use Java List type for OMT array datatype
 - Use Java public modifier for class properties
 - Use boxed or unboxed datatypes for attribues or parameters
+- Export a list of the expanded objects, interactions and datatypes in JSON format
 
 In addition a group ID can be set that will be added to the Java package names.
 

--- a/src/main/java/nl/tno/beangenerator/BeanGenerator.java
+++ b/src/main/java/nl/tno/beangenerator/BeanGenerator.java
@@ -104,6 +104,7 @@ public class BeanGenerator {
   // JSON array of FOM Object and Interaction information.
   private JsonArrayBuilder jsonObjectList = Json.createArrayBuilder();
   private JsonArrayBuilder jsonInteractionList = Json.createArrayBuilder();
+  private JsonArrayBuilder jsonDatatypeList = Json.createArrayBuilder();
 
   ////////////////////////////////////////////////////////////////////////////
   // Public constructors
@@ -245,15 +246,14 @@ public class BeanGenerator {
       throws Exception {}
 
   /**
-   * Callback for json information file. This method is called when the json array of FOM objects
-   * and interactions has been generated for the module the class is a member of. I.e. the selector
-   * value for the module in the expansion call is true.
+   * Callback for the json overview file. This method is called when the json array of FOM objects,
+   * interactions and datatypes has been generated.
    *
-   * @param infoName File name
+   * @param fileName File name
    * @param jsonString JSON contents
    * @throws Exception
    */
-  protected void outputJson(String infoName, String jsonString) throws Exception {}
+  protected void outputJson(String fileName, String jsonString) throws Exception {}
 
   /**
    * Final callback in the expansion.
@@ -263,6 +263,7 @@ public class BeanGenerator {
   protected void afterOutput() throws Exception {
     this.outputJson("objects", this.jsonObjectList.build().toString());
     this.outputJson("interactions", this.jsonInteractionList.build().toString());
+    this.outputJson("datatypes", this.jsonDatatypeList.build().toString());
   }
 
   ////////////////////////////////////////////////////////////////////////////
@@ -420,28 +421,6 @@ public class BeanGenerator {
               enumeratedData.getName().getValue());
         }
       }
-    }
-  }
-
-  ////////////////////////////////////////////////////////////////////////////
-  // Export Module to JSON
-  ////////////////////////////////////////////////////////////////////////////
-  private void exportModule() throws Exception {
-    //    this.expandPackageInfo();
-    this.exportObjectClasses(this.toJavaObjectPackageName(this.currentPackageName));
-    //    this.expandInteractionClasses(this.toJavaInteractionPackageName(this.currentPackageName));
-    //    this.expandDataTypes();
-  }
-
-  ////////////////////////////////////////////////////////////////////////////
-  // Export Object Classes in the current module
-  ////////////////////////////////////////////////////////////////////////////
-  /** Export the object classes in the current module. */
-  private void exportObjectClasses(String objectPackageName) throws Exception {
-    if (this.currentModule.getObjects() != null
-        && this.currentModule.getObjects().getObjectClass() != null) {
-      ObjectClass root = this.currentModule.getObjects().getObjectClass();
-      this.exportObjectClassInformation(null, null, root, objectPackageName);
     }
   }
 
@@ -976,6 +955,76 @@ public class BeanGenerator {
         sb);
   }
 
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Module to JSON
+  ////////////////////////////////////////////////////////////////////////////
+  private void exportModule() throws Exception {
+    //    this.expandPackageInfo();
+    this.exportObjectClasses(this.toJavaObjectPackageName(this.currentPackageName));
+    this.exportInteractionClasses(this.toJavaInteractionPackageName(this.currentPackageName));
+    this.exportDataTypes();
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Object Classes in the current module
+  ////////////////////////////////////////////////////////////////////////////
+  /** Export the object classes in the current module. */
+  private void exportObjectClasses(String objectPackageName) throws Exception {
+    if (this.currentModule.getObjects() != null
+        && this.currentModule.getObjects().getObjectClass() != null) {
+      ObjectClass root = this.currentModule.getObjects().getObjectClass();
+      this.exportObjectClassInformation(null, null, root, objectPackageName);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Interaction Classes in the current module
+  ////////////////////////////////////////////////////////////////////////////
+  /** Expand the interaction classes in the current module. */
+  private void exportInteractionClasses(String interactionPackageName) throws Exception {
+    if (this.currentModule.getInteractions() != null
+        && this.currentModule.getInteractions().getInteractionClass() != null) {
+      InteractionClass root = this.currentModule.getInteractions().getInteractionClass();
+      this.exportInteractionClass(null, null, root, interactionPackageName);
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Datatypes
+  ////////////////////////////////////////////////////////////////////////////
+  /** Export the data types in the current OMT module. */
+  private void exportDataTypes() throws Exception {
+    if (this.currentModule.getDataTypes() != null) {
+
+      FixedRecordDataTypesType fixedRecordDataTypesType =
+          this.currentModule.getDataTypes().getFixedRecordDataTypes();
+      if (fixedRecordDataTypesType != null) {
+        List<FixedRecordData> list = fixedRecordDataTypesType.getFixedRecordData();
+        for (FixedRecordData fixedRecordData : list) {
+          this.exportFixedRecordDataType(fixedRecordData);
+        }
+      }
+
+      VariantRecordDataTypesType variantRecordDataTypesType =
+          this.currentModule.getDataTypes().getVariantRecordDataTypes();
+      if (variantRecordDataTypesType != null) {
+        List<VariantRecordData> list = variantRecordDataTypesType.getVariantRecordData();
+        for (VariantRecordData variantRecordData : list) {
+          this.exportVariantRecordDataType(variantRecordData);
+        }
+      }
+
+      EnumeratedDataTypesType enumeratedDataTypesType =
+          this.currentModule.getDataTypes().getEnumeratedDataTypes();
+      if (enumeratedDataTypesType != null) {
+        List<EnumeratedData> list = enumeratedDataTypesType.getEnumeratedData();
+        for (EnumeratedData enumeratedData : list) {
+          this.exportEnumeratedDataType(enumeratedData);
+        }
+      }
+    }
+  }
+
   /**
    * Export the OMT object class information to JSON.
    *
@@ -1004,44 +1053,190 @@ public class BeanGenerator {
     }
 
     JsonObjectBuilder jb = Json.createObjectBuilder();
-    jb.add("FullyQualifiedName", fqObjectClassName);
-    jb.add("Name", oc.getName().getValue());
+    jb.add("fullyQualifiedName", fqObjectClassName);
+    jb.add("name", oc.getName().getValue());
     if (oc.getSemantics() != null) {
       jb.add("Semantics", oc.getSemantics().getValue());
     }
 
-    // TODO:
-    //    // CLASS MEMBERS
-    //    List<String> memberTypeList = new ArrayList();
-    //    List<String> memberNameList = new ArrayList();
-    //
-    //    for (Attribute attribute : oc.getAttribute()) {
-    //      buildClassMember(
-    //          sb,
-    //          attribute.getName().getValue(),
-    //          attribute.getDataType().getValue(),
-    //          attribute.getSemantics(),
-    //          memberTypeList,
-    //          memberNameList,
-    //          properties.isUseUnboxedType());
-    //      sb.append("\n");
-    //    }
+    // CLASS MEMBERS
+    JsonArrayBuilder members = Json.createArrayBuilder();
+    for (Attribute attribute : oc.getAttribute()) {
+      exportClassMember(
+          members,
+          attribute.getName().getValue(),
+          attribute.getDataType().getValue(),
+          attribute.getSemantics(),
+          properties.isUseUnboxedType());
+    }
+    jb.add("members", members.build());
 
+    // Output the data
     this.jsonObjectList.add(jb.build());
+  }
+
+  /**
+   * Export the provided OMT interaction class information to JSON.
+   *
+   * @param fqParentName: fully qualified name of the parent interaction, or null if there is no
+   *     parent.
+   * @param parent: reference to the parent interaction class, or null if there is no parent.
+   * @param oc: interaction class to be exported.
+   * @throws Exception
+   */
+  private void exportInteractionClass(
+      String fqParentName,
+      InteractionClass parent,
+      InteractionClass ic,
+      String interactionPackageName)
+      throws Exception {
+    String fqInteractionClassName =
+        fqParentName == null
+            ? ic.getName().getValue()
+            : fqParentName + PKG_SEPARATOR + ic.getName().getValue();
+
+    // Recursively expand subclasses.
+    for (InteractionClass subic : ic.getInteractionClass()) {
+      this.exportInteractionClass(fqInteractionClassName, ic, subic, interactionPackageName);
+    }
+
+    // If the class is a scaffolding class then do not expand.
+    if (OmtFunctions.isScaffoldingClass(ic)) {
+      return;
+    }
+
+    JsonObjectBuilder jb = Json.createObjectBuilder();
+    jb.add("fullyQualifiedName", fqInteractionClassName);
+    jb.add("name", ic.getName().getValue());
+    if (ic.getSemantics() != null) {
+      jb.add("semantics", ic.getSemantics().getValue());
+    }
+
+    // MEMBERS
+    JsonArrayBuilder members = Json.createArrayBuilder();
+    for (Parameter p : ic.getParameter()) {
+      exportClassMember(
+          members,
+          p.getName().getValue(),
+          p.getDataType().getValue(),
+          p.getSemantics(),
+          properties.isUseUnboxedType());
+    }
+    jb.add("members", members.build());
+
+    // Output the data
+    this.jsonInteractionList.add(jb.build());
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Fixed Record Datatype
+  ////////////////////////////////////////////////////////////////////////////
+  private void exportFixedRecordDataType(FixedRecordData fixedRecordData) throws Exception {
+    JsonObjectBuilder job = Json.createObjectBuilder();
+
+    job.add("semantics", fixedRecordData.getSemantics().getValue());
+    job.add("name", fixedRecordData.getName().getValue());
+
+    // FIELDS
+    JsonArrayBuilder fields = Json.createArrayBuilder();
+    for (Field f : fixedRecordData.getField()) {
+      // Ignore this field if it has a padding type.
+      if (!this.paddingDataTypes.contains(f.getDataType().getValue())) {
+        exportClassMember(
+            fields, f.getName().getValue(), f.getDataType().getValue(), f.getSemantics(), true);
+      }
+    }
+    job.add("fields", fields.build());
+
+    // Output the data.
+    this.jsonDatatypeList.add(job.build());
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Variant Record Datatype
+  ////////////////////////////////////////////////////////////////////////////
+  private void exportVariantRecordDataType(VariantRecordData variantRecordData) throws Exception {
+    JsonObjectBuilder job = Json.createObjectBuilder();
+
+    job.add("name", variantRecordData.getName().getValue());
+    if (variantRecordData.getSemantics() != null) {
+      job.add("semantics", variantRecordData.getSemantics().getValue());
+    }
+
+    // FIELDS
+    // Map the field name and datatype name to Java
+    String javaDiscriminantName =
+        OmtJavaMapping.toJavaName(variantRecordData.getDiscriminant().getValue());
+    String javaDatatypeName =
+        OmtJavaMapping.getJavaDatatypeNameForEnumerationType(
+            this.omtModules, variantRecordData.getDataType().getValue(), false);
+
+    job.add("javaDiscriminantName", javaDiscriminantName);
+    job.add("javaDatatypeName", javaDatatypeName);
+
+    JsonArrayBuilder alternatives = Json.createArrayBuilder();
+    for (Alternative f : variantRecordData.getAlternative()) {
+      this.exportClassMember(
+          alternatives, f.getName().getValue(), f.getDataType().getValue(), f.getSemantics(), true);
+    }
+    job.add("alternatives", alternatives.build());
+
+    // Output the data.
+    this.jsonDatatypeList.add(job.build());
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Enumerated Datatype
+  ////////////////////////////////////////////////////////////////////////////
+  private void exportEnumeratedDataType(EnumeratedData enumeratedData) throws Exception {
+    JsonObjectBuilder job = Json.createObjectBuilder();
+
+    job.add("name", enumeratedData.getName().getValue());
+    if (enumeratedData.getSemantics() != null) {
+      job.add("semantics", enumeratedData.getSemantics().getValue());
+    }
+    job.add("representation", enumeratedData.getRepresentation().getValue());
+
+    JsonArrayBuilder enumerators = Json.createArrayBuilder();
+    for (Enumerator e : enumeratedData.getEnumerator()) {
+      JsonObjectBuilder enumerator = Json.createObjectBuilder();
+      enumerator.add("name", e.getName().getValue());
+      enumerator.add("value", e.getValue().getFirst().getValue());
+      enumerators.add(enumerator.build());
+    }
+    job.add("enumerators", enumerators.build());
+
+    this.jsonDatatypeList.add(job.build());
   }
 
   ////////////////////////////////////////////////////////////////////////////
   // Create the file
   ////////////////////////////////////////////////////////////////////////////
+
   /**
    * This method creates a source code file. The source code is formatted before being output to the
    * file.
    */
   protected void createFile(String fileName, StringBuilder sb) throws IOException {
+    createFile(fileName, sb, true);
+  }
+
+  /**
+   * This method creates a source code file. The source code is formatted before being output to the
+   * file.
+   */
+  protected void createFile(String fileName, StringBuilder sb, boolean useFormatJava)
+      throws IOException {
+    if (fileName == null || sb == null)
+      throw new IOException("Filename or String contents are null");
     // format the code
     String sourceCode;
     try {
-      sourceCode = new Formatter().formatSource(sb.toString());
+      if (useFormatJava) {
+        sourceCode = new Formatter().formatSource(sb.toString());
+      } else {
+        sourceCode = sb.toString();
+      }
     } catch (FormatterException ex) {
       Logger.getLogger(BeanGenerator.class.getName()).log(Level.SEVERE, null, ex);
       sourceCode = sb.toString();
@@ -1127,6 +1322,54 @@ public class BeanGenerator {
 
     memberTypeList.add(javaDatatypeName);
     memberNameList.add(javaVariableName);
+  }
+
+  private void exportClassMember(
+      JsonArrayBuilder jab,
+      String fieldName,
+      String datatypeName,
+      HLAString semantics,
+      boolean unboxed)
+      throws Exception {
+
+    JsonObjectBuilder job = Json.createObjectBuilder();
+    job.add("fieldName", fieldName);
+    job.add("datatypeName", datatypeName);
+    if (semantics != null) {
+      job.add("semantics", semantics.getValue());
+    }
+
+    int dim = 0;
+    ArrayData arrayData = OmtFunctions.getArrayDataByName(this.omtModules, datatypeName);
+
+    // Drill down the array and count the dimensions.
+    while (arrayData != null) {
+      if (OmtJavaMapping.getJavaDatatypeName(datatypeName) != null) {
+        // If a specific mapping is specified, then break.
+        break;
+      }
+
+      // If a String datatype is met, then break. A String datatype is an array of charachters.
+      if (arrayData.getDataType().getValue().equals(OmtMimConstants.HLAUNICODECHAR)
+          || arrayData.getDataType().getValue().equals(OmtMimConstants.HLAASCIICHAR)) {
+        break;
+      }
+
+      dim++;
+      datatypeName = arrayData.getDataType().getValue();
+      arrayData = OmtFunctions.getArrayDataByName(this.omtModules, datatypeName);
+    }
+
+    // Get the Java data type name, taking into account the expansion properties (list, box type)
+    String javaDatatypeName =
+        OmtJavaMapping.getJavaDatatypeName(
+            this.omtModules, datatypeName, dim, this.properties.isUseList(), !unboxed);
+    String javaVariableName = OmtJavaMapping.toJavaName(fieldName);
+
+    job.add("javaDatatypeName", javaDatatypeName);
+    job.add("javaVariableName", javaVariableName);
+
+    jab.add(job.build());
   }
 
   /**

--- a/src/main/java/nl/tno/beangenerator/BeanGenerator.java
+++ b/src/main/java/nl/tno/beangenerator/BeanGenerator.java
@@ -2,6 +2,9 @@ package nl.tno.beangenerator;
 
 import com.google.googlejavaformat.java.Formatter;
 import com.google.googlejavaformat.java.FormatterException;
+import jakarta.json.Json;
+import jakarta.json.JsonArrayBuilder;
+import jakarta.json.JsonObjectBuilder;
 import java.io.File;
 import java.io.IOException;
 import java.io.PrintWriter;
@@ -64,6 +67,7 @@ public class BeanGenerator {
   public static final String PKG_SEPARATOR = ".";
   public static final String DIR_SEPARATOR = "/";
   public static final String JAVA_FILE_SUFFIX = ".java";
+  public static final String JSON_FILE_SUFFIX = ".json";
   public static final String HLA_UNKNOWN_ENUM = "HLAunknown";
 
   ////////////////////////////////////////////////////////////////////////////
@@ -96,6 +100,10 @@ public class BeanGenerator {
 
   // Set of array datatypes with a padding encoding, not to be expanded.
   private Set<String> paddingDataTypes;
+
+  // JSON array of FOM Object and Interaction information.
+  private JsonArrayBuilder jsonObjectList = Json.createArrayBuilder();
+  private JsonArrayBuilder jsonInteractionList = Json.createArrayBuilder();
 
   ////////////////////////////////////////////////////////////////////////////
   // Public constructors
@@ -237,11 +245,25 @@ public class BeanGenerator {
       throws Exception {}
 
   /**
+   * Callback for json information file. This method is called when the json array of FOM objects
+   * and interactions has been generated for the module the class is a member of. I.e. the selector
+   * value for the module in the expansion call is true.
+   *
+   * @param infoName File name
+   * @param jsonString JSON contents
+   * @throws Exception
+   */
+  protected void outputJson(String infoName, String jsonString) throws Exception {}
+
+  /**
    * Final callback in the expansion.
    *
    * @throws Exception
    */
-  protected void afterOutput() throws Exception {}
+  protected void afterOutput() throws Exception {
+    this.outputJson("objects", this.jsonObjectList.build().toString());
+    this.outputJson("interactions", this.jsonInteractionList.build().toString());
+  }
 
   ////////////////////////////////////////////////////////////////////////////
   // Main expansion method
@@ -288,6 +310,9 @@ public class BeanGenerator {
 
       if (selectors[i]) {
         this.expandModule();
+        if (properties.isUseJsonExport()) {
+          this.exportModule();
+        }
       } else {
         this.declareModule();
       }
@@ -395,6 +420,28 @@ public class BeanGenerator {
               enumeratedData.getName().getValue());
         }
       }
+    }
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Module to JSON
+  ////////////////////////////////////////////////////////////////////////////
+  private void exportModule() throws Exception {
+    //    this.expandPackageInfo();
+    this.exportObjectClasses(this.toJavaObjectPackageName(this.currentPackageName));
+    //    this.expandInteractionClasses(this.toJavaInteractionPackageName(this.currentPackageName));
+    //    this.expandDataTypes();
+  }
+
+  ////////////////////////////////////////////////////////////////////////////
+  // Export Object Classes in the current module
+  ////////////////////////////////////////////////////////////////////////////
+  /** Export the object classes in the current module. */
+  private void exportObjectClasses(String objectPackageName) throws Exception {
+    if (this.currentModule.getObjects() != null
+        && this.currentModule.getObjects().getObjectClass() != null) {
+      ObjectClass root = this.currentModule.getObjects().getObjectClass();
+      this.exportObjectClassInformation(null, null, root, objectPackageName);
     }
   }
 
@@ -927,6 +974,60 @@ public class BeanGenerator {
         this.toDatatypePackageName(this.currentPackageName),
         enumeratedData.getName().getValue(),
         sb);
+  }
+
+  /**
+   * Export the OMT object class information to JSON.
+   *
+   * @param fqParentName: fully qualified name of the parent object class, or null if there is no
+   *     parent.
+   * @param parent: reference to the parent object class, or null if there is no parent.
+   * @param oc: object class to be expanded.
+   * @throws Exception
+   */
+  private void exportObjectClassInformation(
+      String fqParentName, ObjectClass parent, ObjectClass oc, String objectPackageName)
+      throws Exception {
+    String fqObjectClassName =
+        fqParentName == null
+            ? oc.getName().getValue()
+            : fqParentName + PKG_SEPARATOR + oc.getName().getValue();
+
+    // Recursively expand subclasses.
+    for (ObjectClass suboc : oc.getObjectClass()) {
+      this.exportObjectClassInformation(fqObjectClassName, oc, suboc, objectPackageName);
+    }
+
+    // If the class is a scaffolding class then do not expand.
+    if (OmtFunctions.isScaffoldingClass(oc)) {
+      return;
+    }
+
+    JsonObjectBuilder jb = Json.createObjectBuilder();
+    jb.add("FullyQualifiedName", fqObjectClassName);
+    jb.add("Name", oc.getName().getValue());
+    if (oc.getSemantics() != null) {
+      jb.add("Semantics", oc.getSemantics().getValue());
+    }
+
+    // TODO:
+    //    // CLASS MEMBERS
+    //    List<String> memberTypeList = new ArrayList();
+    //    List<String> memberNameList = new ArrayList();
+    //
+    //    for (Attribute attribute : oc.getAttribute()) {
+    //      buildClassMember(
+    //          sb,
+    //          attribute.getName().getValue(),
+    //          attribute.getDataType().getValue(),
+    //          attribute.getSemantics(),
+    //          memberTypeList,
+    //          memberNameList,
+    //          properties.isUseUnboxedType());
+    //      sb.append("\n");
+    //    }
+
+    this.jsonObjectList.add(jb.build());
   }
 
   ////////////////////////////////////////////////////////////////////////////

--- a/src/main/java/nl/tno/beangenerator/BeanGeneratorProperties.java
+++ b/src/main/java/nl/tno/beangenerator/BeanGeneratorProperties.java
@@ -18,210 +18,219 @@ import java.util.Set;
 import nl.tno.omt.helpers.OmtJavaMapping;
 
 /**
- * This class defines several options that can be set or unset to control the
- * code expansion by the Bean Generator.
+ * This class defines several options that can be set or unset to control the code expansion by the
+ * Bean Generator.
  *
  * @author bergtwvd
  */
 public class BeanGeneratorProperties {
 
-	private static final Jsonb jsonb = JsonbBuilder.create(new JsonbConfig().withFormatting(Boolean.TRUE));
+  private static final Jsonb jsonb =
+      JsonbBuilder.create(new JsonbConfig().withFormatting(Boolean.TRUE));
 
-	static public BeanGeneratorProperties read(File file) throws Exception {
-		return jsonb.fromJson(new FileReader(file), BeanGeneratorProperties.class);
-	}
+  public static BeanGeneratorProperties read(File file) throws Exception {
+    return jsonb.fromJson(new FileReader(file), BeanGeneratorProperties.class);
+  }
 
-	static public BeanGeneratorProperties read(URL url) throws Exception {
-		return jsonb.fromJson(url.openStream(), BeanGeneratorProperties.class);
-	}
+  public static BeanGeneratorProperties read(URL url) throws Exception {
+    return jsonb.fromJson(url.openStream(), BeanGeneratorProperties.class);
+  }
 
-	static public void write(File file, BeanGeneratorProperties properties) throws IOException {
-		try (FileWriter fw = new FileWriter(file)) {
-			jsonb.toJson(properties, fw);
-		}
-	}
+  public static void write(File file, BeanGeneratorProperties properties) throws IOException {
+    try (FileWriter fw = new FileWriter(file)) {
+      jsonb.toJson(properties, fw);
+    }
+  }
 
-	static public void write(StringBuilder sb, BeanGeneratorProperties properties) {
-		sb.append(jsonb.toJson(properties));
-	}
+  public static void write(StringBuilder sb, BeanGeneratorProperties properties) {
+    sb.append(jsonb.toJson(properties));
+  }
 
-	/**
-	 * Use fully qualified Java class names to ensure uniqueness, with the
-	 * effect of long class names.
-	 */
-	private boolean useFQclassName = false;
+  /**
+   * Use fully qualified Java class names to ensure uniqueness, with the effect of long class names.
+   */
+  private boolean useFQclassName = false;
 
-	/**
-	 * Use the Java List<T> type instead of T[] for OMT array data types.
-	 */
-	private boolean useList = false;
+  /** Use the Java List<T> type instead of T[] for OMT array data types. */
+  private boolean useList = false;
 
-	/**
-	 * Do not use notice message in each file.
-	 */
-	private boolean useNoNotice = false;
+  /** Do not use notice message in each file. */
+  private boolean useNoNotice = false;
 
-	/**
-	 * Use boxed Java types for each Java class property. Boxing only applies to
-	 * Java classes that relate to OMT classes, and not the Java classes that
-	 * relate to OMT data types.
-	 */
-	private boolean useUnboxedType = false;
+  /**
+   * Use boxed Java types for each Java class property. Boxing only applies to Java classes that
+   * relate to OMT classes, and not the Java classes that relate to OMT data types.
+   */
+  private boolean useUnboxedType = false;
 
-	/**
-	 * Use a public vs a private modifier for Java class properties. This allows
-	 * field-level access to class properties, rather than via the get/set
-	 * methods.
-	 */
-	private boolean usePublicModifier = false;
+  /**
+   * Use a public vs a private modifier for Java class properties. This allows field-level access to
+   * class properties, rather than via the get/set methods.
+   */
+  private boolean usePublicModifier = false;
 
-	/**
-	 * Default package names for modules; the first argument is a regex, the
-	 * second is the package name.
-	 */
-	private Map<String, String> defaultPackageNames = new HashMap();
+  /**
+   * Export the FOM to a JSON file, that allows for transferring FOM information to other
+   * applications such as dashboards.
+   */
+  private boolean useJsonExport = false;
 
-	/**
-	 * Default group id that is prefixed to a package name.
-	 */
-	private String groupId = "nl.tno";
+  /**
+   * Default package names for modules; the first argument is a regex, the second is the package
+   * name.
+   */
+  private Map<String, String> defaultPackageNames = new HashMap();
 
-	/**
-	 * Set of OMT encoding names. For OMT fixed record fields that have an
-	 * encoding in this set no code will be generated. The encoding concerns a
-	 * padding, and the encoding if for a byte array by definition.
-	 */
-	private Set<String> paddingEncodings = new HashSet();
+  /** Default group id that is prefixed to a package name. */
+  private String groupId = "nl.tno";
 
-	/**
-	 * Additional representation mapping to the corresponding Java primitive
-	 * type.
-	 */
-	private Map<String, OmtJavaMapping.JavaPrimitiveType> additionalRepresentationMapping = new HashMap();
+  /**
+   * Set of OMT encoding names. For OMT fixed record fields that have an encoding in this set no
+   * code will be generated. The encoding concerns a padding, and the encoding if for a byte array
+   * by definition.
+   */
+  private Set<String> paddingEncodings = new HashSet();
 
-	/**
-	 * Additional OMT datatype mapping to corresponding Java type, and required Java import.
-	 */
-	private Map<String, Entry<String, List<String>>> additionalDatatypeMapping = new HashMap();
+  /** Additional representation mapping to the corresponding Java primitive type. */
+  private Map<String, OmtJavaMapping.JavaPrimitiveType> additionalRepresentationMapping =
+      new HashMap();
 
-	public BeanGeneratorProperties() {
-		// default package name mapping for NETN package names
-		defaultPackageNames.put(".*netn.?ais.*", "netn.ais");
-		defaultPackageNames.put(".*netn.?base.*", "netn.base");
-		defaultPackageNames.put(".*netn.?cbrn.*", "netn.cbrn");
-		defaultPackageNames.put(".*netn.?com.*", "netn.com");
-		defaultPackageNames.put(".*netn.?etr.*", "netn.etr");
-		defaultPackageNames.put(".*netn.?log.*", "netn.log");
-		defaultPackageNames.put(".*netn.?metoc.*", "netn.metoc");
-		defaultPackageNames.put(".*netn.?mrm.*", "netn.mrm");
-		defaultPackageNames.put(".*netn.?org.*", "netn.org");
-		defaultPackageNames.put(".*netn.?physical.*", "netn.physical");
-		defaultPackageNames.put(".*netn.?se.*", "netn.se");
-		defaultPackageNames.put(".*netn.?tmr.*", "netn.tmr");
+  /** Additional OMT datatype mapping to corresponding Java type, and required Java import. */
+  private Map<String, Entry<String, List<String>>> additionalDatatypeMapping = new HashMap();
 
-		// default pattern for RPR package name
-		defaultPackageNames.put(".*rpr.?fom.*", "rpr");
+  public BeanGeneratorProperties() {
+    // default package name mapping for NETN package names
+    defaultPackageNames.put(".*netn.?ais.*", "netn.ais");
+    defaultPackageNames.put(".*netn.?base.*", "netn.base");
+    defaultPackageNames.put(".*netn.?cbrn.*", "netn.cbrn");
+    defaultPackageNames.put(".*netn.?com.*", "netn.com");
+    defaultPackageNames.put(".*netn.?etr.*", "netn.etr");
+    defaultPackageNames.put(".*netn.?log.*", "netn.log");
+    defaultPackageNames.put(".*netn.?metoc.*", "netn.metoc");
+    defaultPackageNames.put(".*netn.?mrm.*", "netn.mrm");
+    defaultPackageNames.put(".*netn.?org.*", "netn.org");
+    defaultPackageNames.put(".*netn.?physical.*", "netn.physical");
+    defaultPackageNames.put(".*netn.?se.*", "netn.se");
+    defaultPackageNames.put(".*netn.?tmr.*", "netn.tmr");
 
-		// default pattern for CyberDEM package name
-		defaultPackageNames.put(".*cyber.*", "cyber");
+    // default pattern for RPR package name
+    defaultPackageNames.put(".*rpr.?fom.*", "rpr");
 
-		// default pattern for MIM package name
-		defaultPackageNames.put(".*hlastandardmim.*", "mim");
+    // default pattern for CyberDEM package name
+    defaultPackageNames.put(".*cyber.*", "cyber");
 
-		// default RPR2 padding encodings; currently only these are supported and relevant
-		paddingEncodings.add("RPRpaddingTo32Array");
-		paddingEncodings.add("RPRpaddingTo64Array");
+    // default pattern for MIM package name
+    defaultPackageNames.put(".*hlastandardmim.*", "mim");
 
-		// additional representation mappings for RPR2
-		additionalRepresentationMapping.put("RPRunsignedInteger8BE", OmtJavaMapping.JavaPrimitiveType.BYTE);
-		additionalRepresentationMapping.put("RPRunsignedInteger16BE", OmtJavaMapping.JavaPrimitiveType.SHORT);
-		additionalRepresentationMapping.put("RPRunsignedInteger32BE", OmtJavaMapping.JavaPrimitiveType.INTEGER);
-		additionalRepresentationMapping.put("RPRunsignedInteger64BE", OmtJavaMapping.JavaPrimitiveType.LONG);
+    // default RPR2 padding encodings; currently only these are supported and relevant
+    paddingEncodings.add("RPRpaddingTo32Array");
+    paddingEncodings.add("RPRpaddingTo64Array");
 
-		// additional datatype mappings for NETN3
-		additionalDatatypeMapping.put("UuidArrayOfHLAbyte16", new SimpleEntry("UUID", List.of("java.util.UUID")));
-		additionalDatatypeMapping.put("UUID", new SimpleEntry("UUID", List.of("java.util.UUID")));
-		additionalDatatypeMapping.put("TransactionId", new SimpleEntry("UUID", List.of("java.util.UUID")));
-	}
+    // additional representation mappings for RPR2
+    additionalRepresentationMapping.put(
+        "RPRunsignedInteger8BE", OmtJavaMapping.JavaPrimitiveType.BYTE);
+    additionalRepresentationMapping.put(
+        "RPRunsignedInteger16BE", OmtJavaMapping.JavaPrimitiveType.SHORT);
+    additionalRepresentationMapping.put(
+        "RPRunsignedInteger32BE", OmtJavaMapping.JavaPrimitiveType.INTEGER);
+    additionalRepresentationMapping.put(
+        "RPRunsignedInteger64BE", OmtJavaMapping.JavaPrimitiveType.LONG);
 
-	public boolean isUseFQclassName() {
-		return useFQclassName;
-	}
+    // additional datatype mappings for NETN3
+    additionalDatatypeMapping.put(
+        "UuidArrayOfHLAbyte16", new SimpleEntry("UUID", List.of("java.util.UUID")));
+    additionalDatatypeMapping.put("UUID", new SimpleEntry("UUID", List.of("java.util.UUID")));
+    additionalDatatypeMapping.put(
+        "TransactionId", new SimpleEntry("UUID", List.of("java.util.UUID")));
+  }
 
-	public void setUseFQclassName(boolean useFQclassName) {
-		this.useFQclassName = useFQclassName;
-	}
+  public boolean isUseFQclassName() {
+    return useFQclassName;
+  }
 
-	public boolean isUseList() {
-		return useList;
-	}
+  public void setUseFQclassName(boolean useFQclassName) {
+    this.useFQclassName = useFQclassName;
+  }
 
-	public void setUseList(boolean useList) {
-		this.useList = useList;
-	}
+  public boolean isUseList() {
+    return useList;
+  }
 
-	public boolean isUseNoNotice() {
-		return useNoNotice;
-	}
+  public void setUseList(boolean useList) {
+    this.useList = useList;
+  }
 
-	public void setNoNotice(boolean noNotice) {
-		this.useNoNotice = noNotice;
-	}
+  public boolean isUseNoNotice() {
+    return useNoNotice;
+  }
 
-	public boolean isUseUnboxedType() {
-		return useUnboxedType;
-	}
+  public void setNoNotice(boolean noNotice) {
+    this.useNoNotice = noNotice;
+  }
 
-	public void setUseUnboxedType(boolean useUnboxedType) {
-		this.useUnboxedType = useUnboxedType;
-	}
+  public boolean isUseUnboxedType() {
+    return useUnboxedType;
+  }
 
-	public boolean isUsePublicModifier() {
-		return usePublicModifier;
-	}
+  public void setUseUnboxedType(boolean useUnboxedType) {
+    this.useUnboxedType = useUnboxedType;
+  }
 
-	public void setUsePublicModifier(boolean usePublicModifier) {
-		this.usePublicModifier = usePublicModifier;
-	}
+  public boolean isUsePublicModifier() {
+    return usePublicModifier;
+  }
 
-	public Map<String, String> getDefaultPackageNames() {
-		return defaultPackageNames;
-	}
+  public void setUsePublicModifier(boolean usePublicModifier) {
+    this.usePublicModifier = usePublicModifier;
+  }
 
-	public void setDefaultPackageNames(Map<String, String> defaultPackageNames) {
-		this.defaultPackageNames = defaultPackageNames;
-	}
+  public boolean isUseJsonExport() {
+    return useJsonExport;
+  }
 
-	public Set<String> getPaddingEncodings() {
-		return paddingEncodings;
-	}
+  public void setUseJsonExport(boolean useJsonExport) {
+    this.useJsonExport = useJsonExport;
+  }
 
-	public void setPaddingEncodings(Set<String> paddingEncodings) {
-		this.paddingEncodings = paddingEncodings;
-	}
+  public Map<String, String> getDefaultPackageNames() {
+    return defaultPackageNames;
+  }
 
-	public Map<String, OmtJavaMapping.JavaPrimitiveType> getAdditionalRepresentationMapping() {
-		return additionalRepresentationMapping;
-	}
+  public void setDefaultPackageNames(Map<String, String> defaultPackageNames) {
+    this.defaultPackageNames = defaultPackageNames;
+  }
 
-	public void setAdditionalRepresentationMapping(Map<String, OmtJavaMapping.JavaPrimitiveType> representations) {
-		this.additionalRepresentationMapping = representations;
-	}
+  public Set<String> getPaddingEncodings() {
+    return paddingEncodings;
+  }
 
-	public Map<String, Entry<String, List<String>>> getAdditionalDatatypeMapping() {
-		return additionalDatatypeMapping;
-	}
+  public void setPaddingEncodings(Set<String> paddingEncodings) {
+    this.paddingEncodings = paddingEncodings;
+  }
 
-	public void setAdditionalDatatypeMapping(Map<String, Entry<String, List<String>>> additionalDatatypeMapping) {
-		this.additionalDatatypeMapping = additionalDatatypeMapping;
-	}	
-	
-	public String getGroupId() {
-		return groupId;
-	}
+  public Map<String, OmtJavaMapping.JavaPrimitiveType> getAdditionalRepresentationMapping() {
+    return additionalRepresentationMapping;
+  }
 
-	public void setGroupId(String groupId) {
-		this.groupId = groupId;
-	}
+  public void setAdditionalRepresentationMapping(
+      Map<String, OmtJavaMapping.JavaPrimitiveType> representations) {
+    this.additionalRepresentationMapping = representations;
+  }
 
+  public Map<String, Entry<String, List<String>>> getAdditionalDatatypeMapping() {
+    return additionalDatatypeMapping;
+  }
+
+  public void setAdditionalDatatypeMapping(
+      Map<String, Entry<String, List<String>>> additionalDatatypeMapping) {
+    this.additionalDatatypeMapping = additionalDatatypeMapping;
+  }
+
+  public String getGroupId() {
+    return groupId;
+  }
+
+  public void setGroupId(String groupId) {
+    this.groupId = groupId;
+  }
 }

--- a/src/main/java/nl/tno/beanserver/BeanServer.java
+++ b/src/main/java/nl/tno/beanserver/BeanServer.java
@@ -169,6 +169,7 @@ public class BeanServer {
           properties.setUseList(ctx.formParam("useList") != null);
           properties.setUseUnboxedType(ctx.formParam("useUnboxedType") != null);
           properties.setUsePublicModifier(ctx.formParam("usePublicModifier") != null);
+          properties.setUseJsonExport(ctx.formParam("useJsonExport") != null);
           properties.setGroupId(ctx.formParam("groupId"));
 
           boolean createJar = ctx.formParam("createJar") != null;
@@ -293,6 +294,13 @@ public class BeanServer {
                               + infoName
                               + JAVA_FILE_SUFFIX,
                           sourceCode);
+                    }
+
+                    @Override
+                    protected void outputJson(String infoName, String jsonString) throws Exception {
+                      this.createFile(
+                          sourceDir + DIR_SEPARATOR + infoName + JSON_FILE_SUFFIX,
+                          new StringBuilder(jsonString));
                     }
                   };
 

--- a/src/main/java/nl/tno/beanserver/BeanServer.java
+++ b/src/main/java/nl/tno/beanserver/BeanServer.java
@@ -300,7 +300,8 @@ public class BeanServer {
                     protected void outputJson(String infoName, String jsonString) throws Exception {
                       this.createFile(
                           sourceDir + DIR_SEPARATOR + infoName + JSON_FILE_SUFFIX,
-                          new StringBuilder(jsonString));
+                          new StringBuilder(jsonString),
+                          false);
                     }
                   };
 

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -39,7 +39,7 @@
                 <label for="useUnboxedType"> Use Java unboxed datatype for class properties</label>
 				<br>
 				<input type="checkbox" id="useJsonExport" name="useJsonExport" value="useJsonExport">
-                <label for="useJsonExport"> Export Object and Interaction information to JSON</label>
+                <label for="useJsonExport"> Export a list of the expanded objects, interactions and datatypes in JSON format</label>
 				<br>
 			</div>
             <br>

--- a/src/main/resources/public/index.html
+++ b/src/main/resources/public/index.html
@@ -38,6 +38,9 @@
 			    <input type="checkbox" id="useUnboxedType" name="useUnboxedType" value="useUnboxedType">
                 <label for="useUnboxedType"> Use Java unboxed datatype for class properties</label>
 				<br>
+				<input type="checkbox" id="useJsonExport" name="useJsonExport" value="useJsonExport">
+                <label for="useJsonExport"> Export Object and Interaction information to JSON</label>
+				<br>
 			</div>
             <br>
             <div>


### PR DESCRIPTION
Added an option to the BeanGenerator for the functionality of exporting a list of the expanded objects, interactions and datatypes in JSON format. 

A possible use-case for this is WebLVC federates that need a description of the bean classes but are not written in Java.